### PR TITLE
Add Gemfile.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,10 +30,6 @@
 ####################
 *.pid
 
-# Lock files #
-##############
-*.lock
-
 # OS generated files #
 ######################
 .DS_Store

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,106 @@
+GIT
+  remote: https://github.com/PerseusDL/JackRDF
+  revision: 5fbf7705226c7613628cafa0f2da6fd226916317
+  specs:
+    JackRDF (1.0.1)
+      json-ld
+      sparql-client
+
+GEM
+  remote: http://rubygems.org/
+  specs:
+    activesupport (5.0.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    backports (3.6.8)
+    concurrent-ruby (1.0.4)
+    domain_name (0.5.20161129)
+      unf (>= 0.0.5, < 1.0.0)
+    erubis (2.7.0)
+    github-markup (1.4.1)
+    hamster (3.0.0)
+      concurrent-ruby (~> 1.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
+    i18n (0.8.0)
+    json-ld (2.1.2)
+      multi_json (~> 1.12)
+      rdf (~> 2.1)
+    kramdown (1.13.2)
+    link_header (0.0.8)
+    logutils (0.6.1)
+    markdown (1.2.0)
+      kramdown (>= 1.5.0)
+      props (>= 1.1.2)
+      textutils (>= 0.10.0)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
+    minitest (5.10.1)
+    multi_json (1.12.1)
+    net-http-persistent (2.9.4)
+    netrc (0.11.0)
+    props (1.1.2)
+    rack (1.6.5)
+    rack-protection (1.5.3)
+      rack
+    rack-test (0.6.3)
+      rack (>= 1.0)
+    rake (12.0.0)
+    rdf (2.2.3)
+      hamster (~> 3.0)
+      link_header (~> 0.0, >= 0.0.8)
+    rest-client (2.0.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
+    rubyzip (1.2.0)
+    sinatra (1.4.8)
+      rack (~> 1.5)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
+    sinatra-contrib (1.4.7)
+      backports (>= 2.0)
+      multi_json
+      rack-protection
+      rack-test
+      sinatra (~> 1.4.0)
+      tilt (>= 1.3, < 3)
+    sinatra-cross_origin (0.3.2)
+    sinatra-reloader (1.0)
+      sinatra-contrib
+    sparql-client (2.1.0)
+      net-http-persistent (~> 2.9)
+      rdf (~> 2.0)
+    textutils (1.4.0)
+      activesupport
+      logutils (>= 0.6.1)
+      props (>= 1.1.2)
+      rubyzip (>= 1.0.0)
+    thread_safe (0.3.5)
+    tilt (2.0.6)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  JackRDF!
+  erubis
+  github-markup
+  markdown
+  minitest
+  rake
+  rest-client
+  sinatra
+  sinatra-cross_origin (~> 0.3.1)
+  sinatra-reloader
+
+BUNDLED WITH
+   1.14.3


### PR DESCRIPTION
The `Gemfile.lock` should always be included in non-gem Ruby applications.

This lockfile is taken from a working instance of the application.